### PR TITLE
Handle bad gateway errors 😇

### DIFF
--- a/lib/handlers/error.dart
+++ b/lib/handlers/error.dart
@@ -1,3 +1,5 @@
+import 'package:televerse/telegram.dart';
+import 'package:televerse/televerse.dart';
 import 'package:xwordle/config/config.dart';
 import 'package:xwordle/utils/utils.dart';
 
@@ -6,6 +8,25 @@ Future<void> errorHandler(Object err, StackTrace stack) async {
     if (WordleConfig.isDebug) {
       print("Error: $err");
       print(stack);
+      return;
+    }
+    if (err is TelegramException && err.isServerExeption) {
+      DateTime now = DateTime.now();
+      Message? msg;
+      while (msg == null) {
+        try {
+          msg = await sendLogs(
+            "⚠️ <b>Server Error</b>\n\n"
+            "<b>Time:</b> ${now.toIso8601String()}\n"
+            "<b>Message:</b> $err\n"
+            "<b>Stack:</b> $stack\n\n"
+            "#error",
+          );
+        } catch (err) {
+          print("Error ignored: $err");
+          await Future.delayed(Duration(minutes: 30));
+        }
+      }
       return;
     }
     await sendLogs("💀 $err\n\n$stack\n\n#error");

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -96,6 +96,7 @@ Future<Message?> sendLogs(String text) async {
     return await bot.api.sendMessage(
       WordleConfig.instance.logsChannel,
       text,
+      parseMode: ParseMode.html,
     );
   } catch (err, stack) {
     try {


### PR DESCRIPTION
Fixes this one.


💀 TelegramException [502]:  (Bad Gateway)

```
#0      HttpClient.postURI (package:televerse/src/utils/http.dart:32:7)
<asynchronous suspension>
#1      RawAPI.sendMessage (package:televerse/src/televerse/raw_api.dart:247:37)
<asynchronous suspension>
#2      sendLogs (package:xwordle/utils/utils.dart:96:12)
<asynchronous suspension>
#3      errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#4      sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#5      errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#6      sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#7      errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#8      sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#9      errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#10     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#11     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#12     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#13     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#14     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#15     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#16     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#17     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#18     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#19     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#20     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#21     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#22     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#23     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#24     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#25     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#26     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#27     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#28     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#29     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#30     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#31     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#32     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#33     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#34     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#35     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#36     sendLogs (package:xwordle/utils/utils.dart:102:7)
<asynchronous suspension>
#37     errorHandler (package:xwordle/handlers/error.dart:11:5)
<asynchronous suspension>
#38     LongPolling._poll (package:televerse/src/televerse/fetch/long_polling.dart:104:11)
<asynchronous suspension>
#39     LongPolling.start (package:televerse/src/televerse/fetch/long_polling.dart:66:7)
<asynchronous suspension>
#40     Televerse.start (package:televerse/src/televerse/televerse.dart:275:14)
<asynchronous suspension>
```

#error