### PR TITLE
Updated daily logging & Fix #38

### DIFF
--- a/lib/config/consts.dart
+++ b/lib/config/consts.dart
@@ -117,11 +117,20 @@ Show some love by sharing the bot with your friends!
   ///
   /// Messages to be sent when the user tries to play the game again after it's over.
   static const excitedMessages = [
-    "Excited? But, you've already played today! Next wordle showing up on {TIME} 👀",
-    "You've already played today! Next wordle showing up on {TIME} 🤖",
-    "I'm glad you're excited for this! 😍 Next wordle showing up on {TIME} 🤖",
-    "Daily one wordle, that's the rule! 🤓 So next up on {TIME} 🤖",
+    "The next Wordle will be available in {TIME}.",
+    "The next Wordle is just {TIME} away. Get ready to flex your vocabulary muscles",
+    "The next Wordle is coming soon. Try gussing the word before it appears in {TIME}?",
+    "The next Wordle is just {TIME} away. I guess you can wait that long.",
     "Counting, 1, 2, 3... 🤓 Next Wordle arrives on {TIME} 🤖",
+  ];
+
+  /// Already Played
+  static const alreadyPlayed = [
+    "You have already played today's Wordle. The next Wordle will be available in {DURATION}.",
+    "Sorry, you can only play Wordle once a day. The next Wordle will be available in {DURATION}.",
+    "You have already used up your daily Wordle. Please wait for {DURATION} for the next Wordle.",
+    "You have already solved today's Wordle. The next Wordle will be available in {DURATION}.",
+    "You have already guessed today's Wordle. The next Wordle will be available in {DURATION}.",
   ];
 
   /// **Welcome Messages**

--- a/lib/handlers/admin.dart
+++ b/lib/handlers/admin.dart
@@ -204,7 +204,7 @@ class Admin {
         return;
       }
       await ctx.replyWithChatAction(ChatAction.typing);
-      final msg = dailyLog(requestedUser: ctx.chat.id);
+      final msg = statsMessage(requestedUser: ctx.chat.id);
       await ctx.reply(msg, parseMode: ParseMode.html);
     };
   }

--- a/lib/handlers/start.dart
+++ b/lib/handlers/start.dart
@@ -13,7 +13,7 @@ MessageHandler startHandler() {
     }
 
     if (game.index == user.lastGame) {
-      final msg = random(MessageStrings.excitedMessages).replaceAll(
+      final msg = random(MessageStrings.alreadyPlayed).replaceAll(
         "{TIME}",
         game.formattedDurationTillNext,
       );

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -124,7 +124,19 @@ Future<void> editLog(int messageId, String text) async {
   }
 }
 
-String dailyLog({int? requestedUser, bool autoLog = false}) {
+Future<void> sendDailyLog() async {
+  try {
+    await sendLogs(statsMessage(autoLog: true));
+  } catch (err, stack) {
+    try {
+      await errorHandler(err, stack);
+    } catch (e) {
+      print(e);
+    }
+  }
+}
+
+String statsMessage({int? requestedUser, bool autoLog = false}) {
   WordleDay day = WordleDB.today;
   WordleUser? user;
   if (requestedUser != null) {


### PR DESCRIPTION
Fixes #38 - both /start and /next was using `MessageStrings.excitedMessages`. Separated both excited messages & already played messages.