### PR TITLE
Changed how word is updated

### DIFF
--- a/bin/xwordle.dart
+++ b/bin/xwordle.dart
@@ -5,9 +5,6 @@ void main(List<String> args) async {
   // Init the bot
   await init();
 
-  // Update the word
-  await updateWord();
-
   // Handle guessed word
   bot.onText(guessHandler());
 
@@ -61,6 +58,7 @@ void main(List<String> args) async {
   final checker = ScopeOptions(customPredicate: Admin.check);
 
   // Admin Handlers
+  bot.command("update", Admin.updateHandler(), options: checker);
   bot.command("mod", Admin.modHandler(), options: checker);
   bot.command("count", Admin.countHandler(), options: checker);
   bot.command('testbroadcast', Admin.testBroadcastHandler(), options: checker);

--- a/lib/config/words.dart
+++ b/lib/config/words.dart
@@ -15,7 +15,6 @@ const List<String> words = [
   "ileum",
   "navel",
   "hotel",
-  "icily",
   "needy",
   "faint",
   "image",

--- a/lib/handlers/admin.dart
+++ b/lib/handlers/admin.dart
@@ -164,8 +164,13 @@ class Admin {
     return (ctx) async {
       await ctx.reply(
         "Okay, I can update the word, do we need to notify the users or reset counters?",
-        replyMarkup:
-            Keyboard().addText("Notify").addText("Reset").oneTime().resized(),
+        replyMarkup: Keyboard()
+            .addText("Notify")
+            .addText("Reset")
+            .row()
+            .addText("Just Update")
+            .oneTime()
+            .resized(),
       );
 
       final r = await conv.waitForTextMessage(chatId: ctx.id);

--- a/lib/handlers/admin.dart
+++ b/lib/handlers/admin.dart
@@ -159,6 +159,15 @@ class Admin {
       await ctx.reply(await msg, parseMode: ParseMode.html);
     };
   }
+
+  static Handler updateHandler() {
+    return (ctx) async {
+      await ctx.reply("Updating the word now!");
+      bool shouldNotify = ctx.args.isNotEmpty && ctx.args[0] == "notify";
+      await updateWord(shouldNotify: shouldNotify);
+      await ctx.reply("Updated the word!");
+    };
+  }
 }
 
 /// Extension isAdmin on ID

--- a/lib/handlers/admin.dart
+++ b/lib/handlers/admin.dart
@@ -163,8 +163,13 @@ class Admin {
   static Handler updateHandler() {
     return (ctx) async {
       await ctx.reply("Updating the word now!");
-      bool shouldNotify = ctx.args.isNotEmpty && ctx.args[0] == "notify";
-      await updateWord(shouldNotify: shouldNotify);
+      final shouldNotify = ctx.args.isNotEmpty && ctx.args[0] == "notify";
+      final shouldReset =
+          shouldNotify || (ctx.args.isNotEmpty && ctx.args[0] == "reset");
+      await updateWord(
+        shouldNotify: shouldNotify,
+        shouldReset: shouldReset,
+      );
       await ctx.reply("Updated the word!");
     };
   }

--- a/lib/handlers/admin.dart
+++ b/lib/handlers/admin.dart
@@ -162,10 +162,21 @@ class Admin {
 
   static Handler updateHandler() {
     return (ctx) async {
-      await ctx.reply("Updating the word now!");
-      final shouldNotify = ctx.args.isNotEmpty && ctx.args[0] == "notify";
-      final shouldReset =
-          shouldNotify || (ctx.args.isNotEmpty && ctx.args[0] == "reset");
+      await ctx.reply(
+        "Okay, I can update the word, do we need to notify the users or reset counters?",
+        replyMarkup:
+            Keyboard().addText("Notify").addText("Reset").oneTime().resized(),
+      );
+
+      final r = await conv.waitForTextMessage(chatId: ctx.id);
+      if (r == null) {
+        await ctx.reply("Cancelling the action.");
+        return;
+      }
+
+      final shouldNotify = r.msg?.text == "Notify";
+      final shouldReset = shouldNotify || r.msg?.text == "Reset";
+
       await updateWord(
         shouldNotify: shouldNotify,
         shouldReset: shouldReset,

--- a/lib/handlers/update.dart
+++ b/lib/handlers/update.dart
@@ -14,7 +14,10 @@ String getWord(int index) {
 }
 
 /// Updates the words, sends notification to subscribed users.
-Future<void> updateWord({bool shouldNotify = false}) async {
+Future<void> updateWord({
+  bool shouldNotify = false,
+  bool shouldReset = false,
+}) async {
   await sendLogs("⏰ Updating word now!");
   if (shouldNotify) {
     await sendLogs("🔔 This time, we will send notifications to users.");
@@ -22,7 +25,9 @@ Future<void> updateWord({bool shouldNotify = false}) async {
   try {
     await sendDailyLog();
     WordleDay day = await _fetchAndUpdateWordleDay();
-    await day.resetCounters();
+    if (shouldReset) {
+      await day.resetCounters();
+    }
     if (shouldNotify) {
       await notifyUsers();
     }

--- a/lib/handlers/update.dart
+++ b/lib/handlers/update.dart
@@ -14,11 +14,18 @@ String getWord(int index) {
 }
 
 /// Updates the words, sends notification to subscribed users.
-Future<void> updateWord() async {
-  await sendLogs("Update word has been called!");
+Future<void> updateWord({bool shouldNotify = false}) async {
+  await sendLogs("⏰ Updating word now!");
+  if (shouldNotify) {
+    await sendLogs("🔔 This time, we will send notifications to users.");
+  }
   try {
+    await sendDailyLog();
     WordleDay day = await _fetchAndUpdateWordleDay();
-    await _scheduleNextUpdate(day);
+    await day.resetCounters();
+    if (shouldNotify) {
+      await notifyUsers();
+    }
   } catch (e, s) {
     await _handleWordUpdateError(e, s);
   }
@@ -33,20 +40,6 @@ Future<WordleDay> _fetchAndUpdateWordleDay() async {
   day.next = launch.add(Duration(days: ix + 1));
   await day.save();
   return day;
-}
-
-/// Schedule the next update
-Future<void> _scheduleNextUpdate(WordleDay day) async {
-  final durationToNext = day.next.difference(DateTime.now());
-  sendLogs(
-    "⏰ Duration to next update call: ${DateUtil.durationString(durationToNext)}",
-  ).ignore();
-  Timer(durationToNext, () async {
-    await sendDailyLog();
-    await day.resetCounters();
-    await updateWord();
-    await notifyUsers();
-  });
 }
 
 /// Handle errors during word update


### PR DESCRIPTION
Now admin must manually update the word with the `/update` command.

## Why this change?

For some reasons, Google Cloud Run is executing the `updateWord` method multiple times. I think this is happening because of the CPUs being shut down when inactive and the whole program is run again when booted up later.

Probably be the reason why it's costing me hard :)